### PR TITLE
Give the colors terminal names

### DIFF
--- a/colors.json
+++ b/colors.json
@@ -4,7 +4,8 @@
   "red": "FF0000",
   "green": "00FF00",
   "blue": "0000FF",
-  "pink": "FF00FF",
+  "magenta": "FF00FF",
   "yellow": "FFFF00",
-  "teal": "00FFFF"
+  "cyan": "00FFFF",
+  "gray": "808080"
 }


### PR DESCRIPTION
Hi @matthewmueller!
There is a small change to make colors.json by default be compatible with terminal colors.
That makes it possible to easily connect such package as [color](https://www.npmjs.com/package/color) with [colors](https://www.npmjs.com/package/colors) :)
